### PR TITLE
support rat annotations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,6 @@ RUN Rscript -e 'BiocManager::install(c( \
   "readxl", \
   "stringr", \
   "vctrs", \
-  "clusterProfiler", \
   "DOSE", \
   "ggridges", \
   "enrichplot", \
@@ -86,6 +85,11 @@ RUN Rscript -e 'BiocManager::install(c( \
   "org.Pt.eg.db", \
   "org.EcSakai.eg.db", \
   "org.Mxanthus.db" \
+  ), update=FALSE)'
+
+RUN apt install --yes libfontconfig1-dev
+RUN Rscript -e 'BiocManager::install(c( \
+  "clusterProfiler" \
   ), update=FALSE)'
 
 RUN python3 -m pip install --upgrade latch imagesize jinja2

--- a/go_pathway.r
+++ b/go_pathway.r
@@ -67,6 +67,7 @@ p("Loading gene annotations")
 suppressMessages(suppressWarnings(library("org.Hs.eg.db", character.only = TRUE)))
 suppressMessages(suppressWarnings(library("org.Mm.eg.db", character.only = TRUE)))
 suppressMessages(suppressWarnings(library("org.Sc.sgd.db", character.only = TRUE)))
+suppressMessages(suppressWarnings(library("org.Rn.eg.db", character.only = TRUE)))
 
 msig_db <- msigdbr(species = msig_species_id) %>% dplyr::select(gs_name, entrez_gene)
 
@@ -80,6 +81,8 @@ get_names_package <- function(package_string) {
     return(org.Mm.eg.db)
   } else if (package_string == "org.Sc.sgd.db") {
     return(org.Sc.sgd.db)
+  } else if (package_string == "org.Rn.eg.db") {
+    return(org.Rn.eg.db)
   } else {
     return(NULL)
   }

--- a/wf/__init__.py
+++ b/wf/__init__.py
@@ -4,7 +4,6 @@ import json
 import os
 import re
 import subprocess
-import time
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
@@ -15,7 +14,8 @@ import imagesize
 from flytekit import LaunchPlan
 from jinja2 import Template
 from latch import medium_task, message, workflow
-from latch.types import LatchAuthor, LatchDir, LatchFile, LatchMetadata, LatchParameter
+from latch.types import (LatchAuthor, LatchDir, LatchFile, LatchMetadata,
+                         LatchParameter)
 
 print = functools.partial(print, flush=True)
 
@@ -24,24 +24,28 @@ class Species(Enum):
     HUMAN = "Homo sapiens"
     MOUSE = "Mus musculus"
     YEAST = "Saccharomyces cerevisiae"
+    RAT = "Rattus norvegicusz"
 
 
 species_2_msig = {
     Species.HUMAN: "Homo sapiens",
     Species.MOUSE: "Mus musculus",
     Species.YEAST: "Saccharomyces cerevisiae",
+    Species.RAT: "Rattus norvegicus",
 }
 
 species_2_go = {
     Species.HUMAN: "org.Hs.eg.db",
     Species.MOUSE: "org.Mm.eg.db",
     Species.YEAST: "org.Sc.sgd.db",
+    Species.RAT: "org.Rn.eg.db",
 }
 
 species_2_kegg = {
     Species.HUMAN: "hsa",
     Species.MOUSE: "mmu",
     Species.YEAST: "sce",
+    Species.RAT: "rno",
 }
 
 

--- a/wf/__init__.py
+++ b/wf/__init__.py
@@ -101,7 +101,7 @@ def pathway_to_genesets_mapping(
                 if split:
                     data = data.split(" ")
                 current.append(data)
-    mapping = Dict(zip(pathway_ids, zip(entrez_ids, gene_names)))
+    mapping = dict(zip(pathway_ids, zip(entrez_ids, gene_names)))
     return {k: v for k, v in mapping.items() if k in relevant_pathway_ids}
 
 
@@ -269,7 +269,7 @@ def parse_gene_groups(
     species: Species,
 ) -> List[Dict[str, Any]]:
     gene_groups = []
-    entrez_id_to_gene = Dict(zip(pathway.core_entrez_ids, pathway.core_enriched_genes))
+    entrez_id_to_gene = dict(zip(pathway.core_entrez_ids, pathway.core_enriched_genes))
 
     pathview_image_width = imagesize.get(str(pathview_path))[0]
 


### PR DESCRIPTION
* introduce ci against registration for python[3.7-3.9]
* support report generation (gene ontology, pathway enrichment) against `org.Rn.sgd.db` (rat annotation map)

tested against ENSEMBL gene ids 